### PR TITLE
Fix Python2 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ SQLAlchemy-ImageAttach = "~1.1.0"
 flake8 = "^3.7.9"
 flake8-import-order = "^0.18.1"
 flake8-import-order-spoqa = "^1.5.0"
+typing = { version = "^3.7", python = "< 3.5" }
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/sqlalchemy_imageattach_boto3.py
+++ b/sqlalchemy_imageattach_boto3.py
@@ -54,9 +54,15 @@ class Boto3S3Store(Store):
     ):
         # type: (...) -> str
         extension = guess_extension(mimetype)
-        key = f'{object_type}/{object_id}/{width}x{height}{extension}'
+        key = '{}/{}/{}x{}{}'.format(
+            object_type,
+            object_id,
+            width,
+            height,
+            extension,
+        )
         if self.prefix:
-            return f'{self.prefix}/{key}'
+            return '{}/{}'.format(self.prefix, key)
         return key
 
     def upload_file(
@@ -71,7 +77,7 @@ class Boto3S3Store(Store):
             ACL=acl,
             Body=data,
             Bucket=self.bucket,
-            CacheControl=f'max-age={self.max_age!s}',
+            CacheControl='max-age={}'.format(self.max_age),
             ContentType=content_type,
             StorageClass='REDUCED_REDUNDANCY' if rrs else 'STANDARD',
             Key=key,
@@ -130,4 +136,4 @@ class Boto3S3Store(Store):
     ):
         # type: (...) -> str
         key = self.get_key(object_type, object_id, width, height, mimetype)
-        return f'{self.public_base_url}/{key}'
+        return '{}/{}'.format(self.public_base_url, key)

--- a/sqlalchemy_imageattach_boto3.py
+++ b/sqlalchemy_imageattach_boto3.py
@@ -1,5 +1,8 @@
 import io
-from typing import Optional, Union
+try:
+    from typing import Optional, Union
+except ImportError:
+    pass
 
 from boto3 import client
 from sqlalchemy_imageattach.store import Store


### PR DESCRIPTION
This package was meant to support python2, but I used f-string syntax by mistake. So I replaced f-string with str.format. And additionally, I made typing dependency optional.